### PR TITLE
WIP: CUDA port

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,11 +48,31 @@ AC_COMPILE_IFELSE(
   [AC_MSG_RESULT([no])
     HAVE_CXX17=no;])
 
+AC_MSG_CHECKING([whether CUDA is available])
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#if !defined(__NVCC__)]]
+    [[#error CUDA not available]]
+    [[#endif]])],
+  [AC_MSG_RESULT([yes])
+    HAVE_CUDA=yes;],
+  [AC_MSG_RESULT([no])
+    HAVE_CUDA=no;])
+
 AM_CONDITIONAL(HAVE_CXX11,test x$HAVE_CXX11 = xyes)
 
 AM_CONDITIONAL(HAVE_CXX14,test x$HAVE_CXX14 = xyes)
 
 AM_CONDITIONAL(HAVE_CXX17,test x$HAVE_CXX17 = xyes)
+
+AM_CONDITIONAL(HAVE_CUDA,test x$HAVE_CUDA = xyes)
+
+AM_COND_IF([HAVE_CUDA],
+[
+  # tell the compiler to compile .cpp files as CUDA C++
+  CPPFLAGS="-x cu"
+])
+
 
 AC_OUTPUT([
   Makefile

--- a/include/propria/detail/config.hpp
+++ b/include/propria/detail/config.hpp
@@ -293,6 +293,25 @@
 # endif // !defined(PROPRIA_DISABLE_VARIABLE_TEMPLATES)
 #endif // !defined(PROPRIA_HAS_VARIABLE_TEMPLATES)
 
+// Support CUDA __host__ __device__ on compilers known to support it
+#if !defined(PROPRIA_HAS_HOST_DEVICE)
+# if !defined(PROPRIA_DISABLE_HOST_DEVICE)
+#  if defined(__CUDACC__)
+#    define PROPRIA_HAS_HOST_DEVICE 1
+#  endif // defined(__CUDACC__)
+# endif // PROPRIA_DISABLE_HOST_DEVICE
+#endif // PROPRIA_HAS_HOST_DEVICE
+#if !defined(PROPRIA_HOST_DEVICE)
+# if defined(PROPRIA_HAS_HOST_DEVICE)
+#  define PROPRIA_HOST_DEVICE __host__ __device__
+#  define PROPRIA_EXEC_CHECK_DISABLE \
+#  pragma nv_exec_check_disable
+# else // defined(PROPRIA_HAS_HOST_DEVICE)
+#  define PROPRIA_HOST_DEVICE
+#  define PROPRIA_EXEC_CHECK_DISABLE
+# endif // defined(PROPRIA_HAS_HOST_DEVICE)
+#endif // !defined(PROPRIA_HOST_DEVICE)
+
 // Enable workarounds for lack of working expression SFINAE.
 #if !defined(PROPRIA_HAS_WORKING_EXPRESSION_SFINAE)
 # if !defined(PROPRIA_DISABLE_WORKING_EXPRESSION_SFINAE)

--- a/include/propria/prefer.hpp
+++ b/include/propria/prefer.hpp
@@ -239,7 +239,9 @@ struct call_traits<T, void(P0, P1, PN PROPRIA_ELLIPSIS),
 
 struct impl
 {
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == identity,
     typename call_traits<T, void(Property)>::result_type
@@ -253,7 +255,9 @@ struct impl
     return PROPRIA_MOVE_CAST(T)(t);
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == call_member,
     typename call_traits<T, void(Property)>::result_type
@@ -268,7 +272,9 @@ struct impl
         PROPRIA_MOVE_CAST(Property)(p));
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == call_free,
     typename call_traits<T, void(Property)>::result_type
@@ -284,7 +290,9 @@ struct impl
         PROPRIA_MOVE_CAST(Property)(p));
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename P0, typename P1>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(P0, P1)>::overload == two_props,
     typename call_traits<T, void(P0, P1)>::result_type
@@ -303,7 +311,9 @@ struct impl
         PROPRIA_MOVE_CAST(P1)(p1));
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename P0, typename P1, typename PROPRIA_ELLIPSIS PN>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(P0, P1, PN PROPRIA_ELLIPSIS)>::overload == n_props,
     typename call_traits<T, void(P0, P1, PN PROPRIA_ELLIPSIS)>::result_type

--- a/include/propria/query.hpp
+++ b/include/propria/query.hpp
@@ -132,7 +132,9 @@ struct call_traits<T, void(Property),
 
 struct impl
 {
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == static_value,
     typename call_traits<T, void(Property)>::result_type
@@ -149,7 +151,9 @@ struct impl
     >::value();
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == call_member,
     typename call_traits<T, void(Property)>::result_type
@@ -163,7 +167,9 @@ struct impl
     return PROPRIA_MOVE_CAST(T)(t).query(PROPRIA_MOVE_CAST(Property)(p));
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == call_free,
     typename call_traits<T, void(Property)>::result_type

--- a/include/propria/require.hpp
+++ b/include/propria/require.hpp
@@ -201,7 +201,9 @@ struct call_traits<T, void(P0, P1, PN PROPRIA_ELLIPSIS),
 
 struct impl
 {
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == identity,
     typename call_traits<T, void(Property)>::result_type
@@ -215,7 +217,9 @@ struct impl
     return PROPRIA_MOVE_CAST(T)(t);
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == call_member,
     typename call_traits<T, void(Property)>::result_type
@@ -230,7 +234,9 @@ struct impl
         PROPRIA_MOVE_CAST(Property)(p));
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == call_free,
     typename call_traits<T, void(Property)>::result_type
@@ -246,7 +252,9 @@ struct impl
         PROPRIA_MOVE_CAST(Property)(p));
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename P0, typename P1>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(P0, P1)>::overload == two_props,
     typename call_traits<T, void(P0, P1)>::result_type
@@ -265,7 +273,9 @@ struct impl
         PROPRIA_MOVE_CAST(P1)(p1));
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename P0, typename P1, typename PROPRIA_ELLIPSIS PN>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(P0, P1, PN PROPRIA_ELLIPSIS)>::overload == n_props,
     typename call_traits<T, void(P0, P1, PN PROPRIA_ELLIPSIS)>::result_type

--- a/include/propria/require_concept.hpp
+++ b/include/propria/require_concept.hpp
@@ -136,7 +136,9 @@ struct call_traits<T, void(Property),
 
 struct impl
 {
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == identity,
     typename call_traits<T, void(Property)>::result_type
@@ -150,7 +152,9 @@ struct impl
     return PROPRIA_MOVE_CAST(T)(t);
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == call_member,
     typename call_traits<T, void(Property)>::result_type
@@ -165,7 +169,9 @@ struct impl
         PROPRIA_MOVE_CAST(Property)(p));
   }
 
+  PROPRIA_EXEC_CHECK_DISABLE
   template <typename T, typename Property>
+  PROPRIA_HOST_DEVICE
   PROPRIA_CONSTEXPR typename enable_if<
     call_traits<T, void(Property)>::overload == call_free,
     typename call_traits<T, void(Property)>::result_type

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,7 @@
-AUTOMAKE_OPTIONS = subdir-objects
+# The reason dependencies is disabled is because nvcc
+# doesn't understand the -MD, etc. options related to
+# automatic dependency tracking
+AUTOMAKE_OPTIONS = subdir-objects no-dependencies
 
 check_PROGRAMS = \
 	cpp03/query_free \


### PR DESCRIPTION
These changes enhance the build system to work with `nvcc` and turn `prefer`, `query`, `require`, and `require_concept` into `__host__ __device__` functions.